### PR TITLE
Kurausukun-style 'split'

### DIFF
--- a/asm/macros/m4a.inc
+++ b/asm/macros/m4a.inc
@@ -31,11 +31,21 @@
 		.set keysplit_\label, . - \starting_note
 		.set _last_note, \starting_note
 	.endif
+	.set _last_split, 0
 	.endm
 
-	.macro split voice:req, ending_note:req
+	.macro split index:req, ending_note:req
+	.if \ending_note < _last_note
+		.if _last_split == 0
+			.error "split's ending_note earlier than previous keysplit's starting_note"
+		.else
+			.error "split's ending_note earlier than previous split's ending_note"
+		.endif
+	.else
 	.rept \ending_note - _last_note
-	  .byte \voice
+	  .byte \index
 	.endr
+	.endif
 	.set _last_note, \ending_note
+	.set _last_split, 1
 	.endm

--- a/asm/macros/m4a.inc
+++ b/asm/macros/m4a.inc
@@ -26,13 +26,16 @@
 	.ifb \starting_note
 		.global keysplit_\label
 		keysplit_\label:
+		.set _last_note, 0
 	.else
 		.set keysplit_\label, . - \starting_note
+		.set _last_note, \starting_note
 	.endif
 	.endm
 
-	.macro split voice:req, n:req
-	.rept \n
+	.macro split voice:req, ending_note:req
+	.rept \ending_note - _last_note
 	  .byte \voice
 	.endr
+	.set _last_note, \ending_note
 	.endm

--- a/sound/keysplit_tables.inc
+++ b/sound/keysplit_tables.inc
@@ -11,25 +11,25 @@
 @ any extra offset calculation.
 
 keysplit piano, 36
-	split 0, 19 @ 36
-	split 1, 15 @ 55
-	split 2, 21 @ 70
-	split 3, 17 @ 91
+	split 0, 55
+	split 1, 70
+	split 2, 91
+	split 3, 108
 
 keysplit strings, 36
-	split 0, 33 @ 36
-	split 1, 12 @ 69
-	split 2, 27 @ 81
+	split 0, 69
+	split 1, 81
+	split 2, 108
 
 keysplit trumpet, 36
-	split 0, 30 @ 36
-	split 1, 18 @ 66
-	split 2, 24 @ 84
+	split 0, 66
+	split 1, 84
+	split 2, 108
 
 keysplit tuba, 24
-	split 0, 18 @ 24
-	split 1, 66 @ 42
+	split 0, 42
+	split 1, 108
 
 keysplit french_horn, 36
-	split 0, 30 @ 36
-	split 1, 42 @ 66
+	split 0, 66
+	split 1, 108


### PR DESCRIPTION
Instead of `split` taking the number of notes, it takes the end note. [As discussed on Discord](https://discord.com/channels/442462691542695948/442465020291317760/1400809658372849867).